### PR TITLE
docs: add doris-profile-reader to README Skills table

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ intentionally out of scope here; use your platform's cluster-management console 
 | `doris-best-practices` | Apache Doris table design, sizing, and runtime query investigation (37 rules, 7 use-case templates, 4 sizing guides) |
 | `doris-architecture-advisor` | Workload-aware architecture design (8 decision rules, 10 worked industry examples) |
 | `doris-debug` | Production diagnostic suite: symptom router + 10 domain skills (query, import, compaction, node, MV, tablet, deployment, data-lake, resource-isolation, cloud), 16 case files, 45 case patterns |
+| `doris-profile-reader` | Query runtime profile interpretation and bottleneck triage (counter semantics, join-order / runtime-filter diagnosis, 9 reference guides) |
 
 ## How to use
 


### PR DESCRIPTION
## What

Add the missing `doris-profile-reader` row to the Skills table in README.md.

## Why

`skills/doris-profile-reader/` exists in the repository (SKILL.md + 9 reference guides + 1 script), but the README Skills table only lists `doris-best-practices` and `doris-architecture-advisor`, so the profile reader is undiscoverable from the landing page.

## Description

Row text follows the style of the existing entries and is derived from the skill's SKILL.md description:

> Query runtime profile interpretation and bottleneck triage (counter semantics, join-order / runtime-filter diagnosis, 9 reference guides)